### PR TITLE
[WIP] Properly exclude folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-sample-plugin",
-	"version": "1.0.22",
+	"version": "1.0.23",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-sample-plugin",
-			"version": "1.0.22",
+			"version": "1.0.23",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "16.11.6",

--- a/src/models/PluginSettingsTab.ts
+++ b/src/models/PluginSettingsTab.ts
@@ -110,7 +110,7 @@ export class PluginSettingsTab extends PluginSettingTab {
 			.setName("Excluded Folders")
 			.setDesc("These Folders will not automatically create an IndexFile")
 			.addTextArea(component => {
-				component.setPlaceholder("Folder1\nFolder2/Foo\nFolder3/Foo/Bar")
+				component.setPlaceholder("Folder1\nFolder2/Foo\nFolder3/*")
 					.setValue(this.plugin.settings.excludeFolders.join("\n"))
 					.onChange(async (value) => {
 						this.plugin.settings.excludeFolders = value.split("\n")

--- a/src/modules/FolderNoteModule.ts
+++ b/src/modules/FolderNoteModule.ts
@@ -81,8 +81,8 @@ export class FolderNoteModule {
 			indexFilePath = this.plugin.settings.rootIndexFile
 		}
 
-		// Create the File if it doesn't exist and isn't excluded, then open it
-		if (!this.doesFileExist(indexFilePath) && (folderName == null || !this.plugin.settings.excludeFolders.includes(folderName))) {
+		// Create the File if it doesn't exist and open it
+		if (!this.doesFileExist(indexFilePath)) {
 			if (await this.createIndexFile(indexFilePath)) {
 				await this.openIndexFile(indexFilePath)
 			}

--- a/src/modules/FolderNoteModule.ts
+++ b/src/modules/FolderNoteModule.ts
@@ -81,8 +81,8 @@ export class FolderNoteModule {
 			indexFilePath = this.plugin.settings.rootIndexFile
 		}
 
-		// Create the File if it doesn't exist and open it
-		if (!this.doesFileExist(indexFilePath)) {
+		// Create the File if it doesn't exist and isn't excluded, then open it
+		if (!this.doesFileExist(indexFilePath) && (folderName == null || !this.plugin.settings.excludeFolders.includes(folderName))) {
 			if (await this.createIndexFile(indexFilePath)) {
 				await this.openIndexFile(indexFilePath)
 			}

--- a/src/types/Utilities.ts
+++ b/src/types/Utilities.ts
@@ -1,5 +1,6 @@
 import {TFile} from "obsidian";
 import FolderIndexPlugin from "../main";
+import * as typescriptPath from "path";
 
 export function isIndexFileWithFile(file: TFile) {
 	return isIndexFile(file.path)
@@ -22,7 +23,7 @@ export function isExcludedPath(path: string) {
 	for (const excludedFolder of FolderIndexPlugin.PLUGIN.settings.excludeFolders) {
 		if (excludedFolder == "")
 			continue
-		if (RegExp(`^${excludedFolder}$`).test(path))
+		if (RegExp(`^${excludedFolder}$`).test(path) || RegExp(`^${excludedFolder}$`).test(typescriptPath.dirname(path)))
 			return true;
 	}
 	return false

--- a/src/types/Utilities.ts
+++ b/src/types/Utilities.ts
@@ -20,9 +20,13 @@ export function isIndexFile(path: string) {
 }
 
 export function isExcludedPath(path: string) {
-	for (const excludedFolder of FolderIndexPlugin.PLUGIN.settings.excludeFolders) {
+	for (let excludedFolder of FolderIndexPlugin.PLUGIN.settings.excludeFolders) {
 		if (excludedFolder == "")
 			continue
+
+		if (excludedFolder.endsWith("/*"))
+			excludedFolder = excludedFolder.slice(0, -1) + ".*";
+		
 		if (RegExp(`^${excludedFolder}$`).test(path) || RegExp(`^${excludedFolder}$`).test(typescriptPath.dirname(path)))
 			return true;
 	}


### PR DESCRIPTION
I made a very small change, which will properly exclude folders (and therefore somewhat fix #68). This will only exclude the "actual" folder though, subfolders still get treated normally. Depending on use-case, this could be favorable or annoying.

I would propose keeping it this way, and adding some basic form of regex (ie. `media/*`) for also excluding subfolders, but I haven't looked into how that should get implemented yet.