### PR TITLE
Add more Local options in codeblock (ignore, limit, etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,38 @@ The `ignore` option supports:
 |-------|---------------------------------------------------|
 | title | This will overwrite the Filename inside the Index |
 
+### Code Block Configuration
+
+The `folder-index-content` code block supports the following configuration options:
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| title | This will overwrite the Filename inside the Index | `title: My Custom Title` |
+| ignore | Files/folders to exclude from the content (supports wildcards) | `ignore: *.pdf, *img*, temp` |
+| recursionLimit | Override the global subfolder limit for this index | `recursionLimit: 2` |
+
+Example:
+```folder-index-content
+title: Project Files
+ignore: *.pdf, *img*, temp
+recursionLimit: 2
+```
+
+### Settings
+
+| Setting | Description |
+|---------|-------------|
+| Graph View | Overwrite the default graph view to show folder structure |
+| Root Index File | The file used for the root index |
+| Initial Content | Default content for new folder indexes |
+| Excluded Folders | Folders that won't create index files automatically |
+| Excluded Patterns | Files/folders to exclude from content (supports wildcards) |
+| Only Show Markdown Files | When enabled, only markdown files will be shown in indexes |
+| Auto Generate Index | Create index files automatically for new folders |
+| Auto Rename Index | Rename index files when folders are renamed |
+| User Defined Index Name | Use a custom name for index files |
+| Index Filename | The custom filename for indexes |
+
 ### Manual Installation
 
 1. Go to [Releases](https://github.com/turulix/obsidian-folder-index/releases) and download the ZIP file from the latest

--- a/README.md
+++ b/README.md
@@ -35,20 +35,7 @@ You can also use the ``folder-index-content`` Block processor directly like this
 ```
 ````
 
-to include the content of the folder index in any note you want
-
-You can also exclude specific files or folders in the code block using the `ignore` option:
-
-````
-```folder-index-content
-ignore: folder1/, *test*, *.pdf
-```
-````
-
-The `ignore` option supports:
-- Multiple patterns separated by commas
-- Wildcards using `*` (e.g., `*.pdf` to exclude all PDF files)
-- This works in addition to the global exclude patterns in the plugin settings
+to include the content of the folder index in any note you want.
 
 #### Frontmatter
 
@@ -67,11 +54,18 @@ The `folder-index-content` code block supports the following configuration optio
 | recursionLimit | Override the global subfolder limit for this index | `recursionLimit: 2` |
 
 Example:
+````md
 ```folder-index-content
 title: Project Files
-ignore: *.pdf, *img*, temp
+ignore: *.pdf, *img*, temp, Folder/
 recursionLimit: 2
 ```
+````
+
+The `ignore` option supports:
+- Multiple patterns separated by commas
+- Wildcards using `*` (e.g., `*.pdf` to exclude all PDF files)
+- This works in addition to the global exclude patterns in the plugin settings
 
 ### Settings
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ You can also use the ``folder-index-content`` Block processor directly like this
 
 to include the content of the folder index in any note you want
 
+You can also exclude specific files or folders in the code block using the `ignore` option:
+
+````
+```folder-index-content
+ignore: folder1/, *test*, *.pdf
+```
+````
+
+The `ignore` option supports:
+- Multiple patterns separated by commas
+- Wildcards using `*` (e.g., `*.pdf` to exclude all PDF files)
+- This works in addition to the global exclude patterns in the plugin settings
+
 #### Frontmatter
 
 | Key   | Description                                       |

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,8 +44,8 @@ export default class FolderIndexPlugin extends Plugin {
 		this.registerEvent(this.app.workspace.on("layout-change", this.onLayoutChange.bind(this)))
 		this.eventManager.on("settingsUpdate", this.onSettingsUpdate.bind(this))
 
-		this.registerMarkdownCodeBlockProcessor("folder-index-content", (_source, el, ctx) => {
-			ctx.addChild(new IndexContentProcessorModule(this.app, this, ctx.sourcePath, el))
+		this.registerMarkdownCodeBlockProcessor("folder-index-content", (source, el, ctx) => {
+			ctx.addChild(new IndexContentProcessorModule(this.app, this, ctx.sourcePath, el, source))
 		})
 
 		this.folderNodeModule = new FolderNoteModule(this.app, this)
@@ -96,5 +96,3 @@ export default class FolderIndexPlugin extends Plugin {
 		this.eventManager.emit("settingsUpdate", this.settings);
 	}
 }
-
-

--- a/src/models/CodeBlockConfig.ts
+++ b/src/models/CodeBlockConfig.ts
@@ -1,0 +1,3 @@
+export interface CodeBlockConfig {
+	ignore: string[];
+}

--- a/src/models/CodeBlockConfig.ts
+++ b/src/models/CodeBlockConfig.ts
@@ -1,3 +1,6 @@
 export interface CodeBlockConfig {
-	ignore: string[];
+	title?: string;
+	type?: string;
+	ignore?: string[];
+	recursionLimit?: number;  // 本地递归层级限制
 }

--- a/src/models/PluginSettingsTab.ts
+++ b/src/models/PluginSettingsTab.ts
@@ -37,6 +37,7 @@ export interface PluginSetting {
 	headlineLimit: number;
 	indexFileUserSpecified: boolean;
 	indexFilename: string;
+	markdownOnly: boolean;
 }
 
 export const DEFAULT_SETTINGS: PluginSetting = {
@@ -61,7 +62,8 @@ export const DEFAULT_SETTINGS: PluginSetting = {
 	recursionLimit: -1,
 	headlineLimit: 6,
 	indexFileUserSpecified: false,
-	indexFilename: "!"
+	indexFilename: "!",
+	markdownOnly: false
 }
 
 export class PluginSettingsTab extends PluginSettingTab {
@@ -140,20 +142,6 @@ export class PluginSettingsTab extends PluginSettingTab {
 			})
 
 		new Setting(containerEl)
-			.setName("Excluded Patterns")
-			.setDesc("Files and folders matching these patterns will be excluded from the content renderer. Use * as wildcard. One pattern per line.")
-			.addTextArea(component => {
-				component.setPlaceholder("Assets\n*img*\n*.pdf")
-					.setValue(this.plugin.settings.excludePatterns.join("\n"))
-					.onChange(async (value) => {
-						this.plugin.settings.excludePatterns = value.split("\n")
-						await this.plugin.saveSettings()
-					})
-				component.inputEl.rows = 8
-				component.inputEl.cols = 50
-			})
-
-		new Setting(containerEl)
 			.setName("Automatically generate IndexFile")
 			.setDesc("This will automatically create an IndexFile when you create a new folder")
 			.addToggle(component => component.setValue(this.plugin.settings.autoCreateIndexFile)
@@ -203,6 +191,29 @@ export class PluginSettingsTab extends PluginSettingTab {
 
 		containerEl.createEl('h2', {text: 'Content Renderer Settings'});
 
+		new Setting(containerEl)
+			.setName("Only Show Markdown Files")
+			.setDesc("When enabled, only markdown files will be shown in the index")
+			.addToggle(component => component.setValue(this.plugin.settings.markdownOnly)
+				.onChange(async (value) => {
+					this.plugin.settings.markdownOnly = value
+					await this.plugin.saveSettings()
+				}))
+
+		new Setting(containerEl)
+		.setName("Excluded Patterns")
+		.setDesc("Files and folders matching these patterns will be excluded from the content renderer. Use * as wildcard. One pattern per line.")
+		.addTextArea(component => {
+			component.setPlaceholder("Assets\n*img*\n*.pdf")
+				.setValue(this.plugin.settings.excludePatterns.join("\n"))
+				.onChange(async (value) => {
+					this.plugin.settings.excludePatterns = value.split("\n")
+					await this.plugin.saveSettings()
+				})
+			component.inputEl.rows = 8
+			component.inputEl.cols = 50
+		})
+		
 		// new Setting(containerEl)
 		// 	.setName("Skip First Headline")
 		// 	.setDesc("This Option should not be used anymore, as Obsidian now shows the Filename itself " +

--- a/src/models/PluginSettingsTab.ts
+++ b/src/models/PluginSettingsTab.ts
@@ -38,6 +38,7 @@ export interface PluginSetting {
 	indexFileUserSpecified: boolean;
 	indexFilename: string;
 	markdownOnly: boolean;
+	onlyOpenIndexByName: boolean;
 }
 
 export const DEFAULT_SETTINGS: PluginSetting = {
@@ -63,7 +64,8 @@ export const DEFAULT_SETTINGS: PluginSetting = {
 	headlineLimit: 6,
 	indexFileUserSpecified: false,
 	indexFilename: "!",
-	markdownOnly: false
+	markdownOnly: false,
+	onlyOpenIndexByName: false
 }
 
 export class PluginSettingsTab extends PluginSettingTab {
@@ -364,5 +366,13 @@ export class PluginSettingsTab extends PluginSettingTab {
 					await this.plugin.saveSettings()
 				}))
 
+		new Setting(containerEl)
+			.setName("Only Open Index By Name")
+			.setDesc("This will only open index files by name")
+			.addToggle(component => component.setValue(this.plugin.settings.onlyOpenIndexByName)
+				.onChange(async (value) => {
+					this.plugin.settings.onlyOpenIndexByName = value
+					await this.plugin.saveSettings()
+				}))
 	}
 }

--- a/src/modules/FolderNoteModule.ts
+++ b/src/modules/FolderNoteModule.ts
@@ -3,230 +3,237 @@ import FolderIndexPlugin from "../main";
 import {isExcludedPath, isIndexFile} from "../types/Utilities";
 
 export class FolderNoteModule {
-	viewModeByPlugin = false;
-	previousState: ViewState | null = null;
+    viewModeByPlugin = false;
+    previousState: ViewState | null = null;
 
-	constructor(private app: App, private plugin: FolderIndexPlugin) {
-		this.app = app;
-		this.plugin = plugin;
-		this.load()
-	}
+    constructor(private app: App, private plugin: FolderIndexPlugin) {
+        this.app = app;
+        this.plugin = plugin;
+        this.load()
+    }
 
-	load() {
-		// Apparently loading the vault also triggers the create event. So we just wait till everything is ready
-		this.app.workspace.onLayoutReady(() => {
-			this.plugin.registerEvent(this.app.vault.on("create", this.onCreate.bind(this)))
-		})
+    load() {
+        // Apparently loading the vault also triggers the create event. So we just wait till everything is ready
+        this.app.workspace.onLayoutReady(() => {
+            this.plugin.registerEvent(this.app.vault.on("create", this.onCreate.bind(this)))
+        })
 
-		this.plugin.registerEvent(this.app.workspace.on("layout-change", this.onLayoutChange.bind(this)))
+        this.plugin.registerEvent(this.app.workspace.on("layout-change", this.onLayoutChange.bind(this)))
 
-		this.plugin.registerDomEvent(document, "click", this.onClick.bind(this))
-		this.plugin.registerEvent(this.app.vault.on("rename", this.onRename.bind(this)))
-	}
+        this.plugin.registerDomEvent(document, "click", this.onClick.bind(this))
+        this.plugin.registerEvent(this.app.vault.on("rename", this.onRename.bind(this)))
+    }
 
-	unload() {
-		// this.plugin.eventManager.off("fileExplorerFolderClick", this.onFolderClick.bind(this))
-		// FolderNoteModule.showAllIndexFiles()
-	}
-
-
-	private getTargetFromEvent(event: MouseEvent): HTMLElement | null {
-		if (!(event.target instanceof HTMLElement)) {
-			return null
-		}
-		const target = event.target
-		// @ts-ignore - This is a hack to get the active plugins.
-		// noinspection JSUnresolvedReference
-		const activePlugins: Set = this.app.plugins.enabledPlugins
-
-		// Compatibility with https://github.com/ozntel/file-tree-alternative
-		if (activePlugins.has("file-tree-alternative")) {
-			if (target.classList.contains("oz-folder-name")) {
-				return (target.parentElement?.parentElement?.parentElement) ?? null
-			}
-			if (target.classList.contains("oz-folder-block")) {
-				return (target.parentElement?.parentElement) ?? null
-			}
-		}
-
-		// We only want to handle clicks on the folders in the file explorer
-		if (target.classList.contains("nav-folder-title"))
-			return target
-		// If the user clicked on the content of the folder, we need to get the parent element
-		if (target.classList.contains("nav-folder-title-content")) {
-			return target.parentElement
-		}
-		return null
-	}
-
-	private indexFilePath(path: string): string {
-		if (this.plugin.settings.indexFileUserSpecified) {
-			return path + "/" + this.plugin.settings.indexFilename + ".md";
-		} else {
-			const folderName = path.split("/").pop();
-			return path + "/" + folderName + ".md";
-		}
-	}
-
-	private async onClick(event: MouseEvent) {
-		const target = this.getTargetFromEvent(event)
-		if (target == null)
-			return
-
-		// Get the path of the clicked folder
-		const dataPathAttribute = target.attributes.getNamedItem("data-path")
-		let dataPath: string
-		if (dataPathAttribute == null) {
-			return
-		} else {
-			dataPath = dataPathAttribute.value
-		}
-
-		let indexFilePath = this.indexFilePath(dataPath)
-
-		// This is the root folder, so we open the root index file
-		if (indexFilePath == "//.md") {
-			indexFilePath = this.plugin.settings.rootIndexFile
-		}
-
-		// Create the File if it doesn't exist and open it
-		if (!this.doesFileExist(indexFilePath)) {
-			if (await this.createIndexFile(indexFilePath)) {
-				await this.openIndexFile(indexFilePath)
-			}
-		} else {
-			await this.openIndexFile(indexFilePath)
-		}
-	}
-
-	private doesFileExist(path: string) {
-		return this.app.vault.getAbstractFileByPath(path) != null
-	}
-
-	private async openIndexFile(path: string) {
-		if (!isIndexFile(path)) {
-			return
-		}
-
-		const file = this.app.vault.getAbstractFileByPath(path)
-		if (file instanceof TFile) {
-			await this.app.workspace.getLeaf(false).openFile(file)
-		}
-	}
-
-	private async createIndexFile(path: string) {
-		if (isExcludedPath(path))
-			return false
-		if (this.plugin.settings.autoCreateIndexFile) {
-			const name = path.split(/\//).last()
-			try {
-				if (!name)
-					return false
-				const file = await this.app.vault.create(path, this.plugin.settings.indexFileInitText.replace("{{folder}}", name))
-				new Notice(`Created index file ${file.basename}`)
-				return true
-			} catch (e) {
-				new Notice(`Failed to create index file ${name}`)
-			}
-		}
-		return false
-	}
-
-	private async onRename(file: TAbstractFile, oldPath: string) {
-
-		if (!this.plugin.settings.autoRenameIndexFile) {
-			return
-		}
-		// We don't care if a file was renamed.
-		if (file instanceof TFile) {
-			return
-		}
-		// The File is a folder within the renamed Folder, so we don't care.
-		if (oldPath.split("/").pop() == file.name) {
-			return;
-		}
-
-		const oldIndexFileName = oldPath.split("/").pop()
-
-		// The Folder didn't contain an index file, so we don't care.
-		// Obsidian is slow, so this still the Path at this time.
-		if (!this.doesFileExist(`${oldPath}/${oldIndexFileName}.md`))
-			return
-
-		// The Folder contained an index file, so we need to rename it.
-
-		const oldIndexFile = this.app.vault.getAbstractFileByPath(`${oldPath}/${oldIndexFileName}.md`) as TFile
-		if (!isIndexFile(oldIndexFile.path))
-			return
-
-		// Since the OS already renamed the folder but Obsidian just hasn't updated yet, we need to change the path manually
-		oldIndexFile.path = `${file.path}/${oldIndexFileName}.md`
+    unload() {
+        // this.plugin.eventManager.off("fileExplorerFolderClick", this.onFolderClick.bind(this))
+        // FolderNoteModule.showAllIndexFiles()
+    }
 
 
-		try {
-			await this.app.vault.rename(oldIndexFile, `${file.path}/${file.name}.md`)
-			new Notice(`Renamed index file ${oldIndexFileName} to ${file.name}`)
-		} catch (e) {
-			new Notice(`Failed to rename index file ${oldIndexFileName} to ${file.name}. ${file.name} will be used as the index file.`)
-		}
+    private getTargetFromEvent(event: MouseEvent): HTMLElement | null {
+        if (!(event.target instanceof HTMLElement)) {
+            return null
+        }
+        const target = event.target
+        // @ts-ignore - This is a hack to get the active plugins.
+        // noinspection JSUnresolvedReference
+        const activePlugins: Set = this.app.plugins.enabledPlugins
+
+        // Compatibility with https://github.com/ozntel/file-tree-alternative
+        if (activePlugins.has("file-tree-alternative")) {
+            if (target.classList.contains("oz-folder-name")) {
+                return (target.parentElement?.parentElement?.parentElement) ?? null
+            }
+            if (target.classList.contains("oz-folder-block")) {
+                return (target.parentElement?.parentElement) ?? null
+            }
+        }
+
+        // We only want to handle clicks on the folders in the file explorer
+        if (target.classList.contains("nav-folder-title"))
+            return target
+        // If the user clicked on the content of the folder, we need to get the parent element
+        if (target.classList.contains("nav-folder-title-content")) {
+            return target.parentElement
+        }
+        return null
+    }
+
+    private indexFilePath(path: string): string {
+        if (this.plugin.settings.indexFileUserSpecified) {
+            return path + "/" + this.plugin.settings.indexFilename + ".md";
+        } else {
+            const folderName = path.split("/").pop();
+            return path + "/" + folderName + ".md";
+        }
+    }
+
+    private async onClick(event: MouseEvent) {
+        const target = this.getTargetFromEvent(event)
+        if (target == null)
+            return
+
+        // Check if we should only handle clicks on folder name
+        if (this.plugin.settings.onlyOpenIndexByName) {
+            if (!(event.target instanceof HTMLElement) || !event.target.classList.contains("nav-folder-title-content")) {
+                return;
+            }
+        }
+
+        // Get the path of the clicked folder
+        const dataPathAttribute = target.attributes.getNamedItem("data-path")
+        let dataPath: string
+        if (dataPathAttribute == null) {
+            return
+        } else {
+            dataPath = dataPathAttribute.value
+        }
+
+        let indexFilePath = this.indexFilePath(dataPath)
+
+        // This is the root folder, so we open the root index file
+        if (indexFilePath == "//.md") {
+            indexFilePath = this.plugin.settings.rootIndexFile
+        }
+
+        // Create the File if it doesn't exist and open it
+        if (!this.doesFileExist(indexFilePath)) {
+            if (await this.createIndexFile(indexFilePath)) {
+                await this.openIndexFile(indexFilePath)
+            }
+        } else {
+            await this.openIndexFile(indexFilePath)
+        }
+    }
+
+    private doesFileExist(path: string) {
+        return this.app.vault.getAbstractFileByPath(path) != null
+    }
+
+    private async openIndexFile(path: string) {
+        if (!isIndexFile(path)) {
+            return
+        }
+
+        const file = this.app.vault.getAbstractFileByPath(path)
+        if (file instanceof TFile) {
+            await this.app.workspace.getLeaf(false).openFile(file)
+        }
+    }
+
+    private async createIndexFile(path: string) {
+        if (isExcludedPath(path))
+            return false
+        if (this.plugin.settings.autoCreateIndexFile) {
+            const name = path.split(/\//).last()
+            try {
+                if (!name)
+                    return false
+                const file = await this.app.vault.create(path, this.plugin.settings.indexFileInitText.replace("{{folder}}", name))
+                new Notice(`Created index file ${file.basename}`)
+                return true
+            } catch (e) {
+                new Notice(`Failed to create index file ${name}`)
+            }
+        }
+        return false
+    }
+
+    private async onRename(file: TAbstractFile, oldPath: string) {
+
+        if (!this.plugin.settings.autoRenameIndexFile) {
+            return
+        }
+        // We don't care if a file was renamed.
+        if (file instanceof TFile) {
+            return
+        }
+        // The File is a folder within the renamed Folder, so we don't care.
+        if (oldPath.split("/").pop() == file.name) {
+            return;
+        }
+
+        const oldIndexFileName = oldPath.split("/").pop()
+
+        // The Folder didn't contain an index file, so we don't care.
+        // Obsidian is slow, so this still the Path at this time.
+        if (!this.doesFileExist(`${oldPath}/${oldIndexFileName}.md`))
+            return
+
+        // The Folder contained an index file, so we need to rename it.
+
+        const oldIndexFile = this.app.vault.getAbstractFileByPath(`${oldPath}/${oldIndexFileName}.md`) as TFile
+        if (!isIndexFile(oldIndexFile.path))
+            return
+
+        // Since the OS already renamed the folder but Obsidian just hasn't updated yet, we need to change the path manually
+        oldIndexFile.path = `${file.path}/${oldIndexFileName}.md`
 
 
-	}
-
-	private async onLayoutChange() {
-		const currentLeaf = this.app.workspace.getMostRecentLeaf()
-		if (currentLeaf == null) {
-			return;
-		}
-		const currentState = currentLeaf.getViewState();
-
-		try {
-			// try {
-			if (this.previousState == null) {
-				this.previousState = currentLeaf.getViewState();
-			}
-			if (!this.plugin.settings.autoPreviewMode) {
-				return;
-			}
+        try {
+            await this.app.vault.rename(oldIndexFile, `${file.path}/${file.name}.md`)
+            new Notice(`Renamed index file ${oldIndexFileName} to ${file.name}`)
+        } catch (e) {
+            new Notice(`Failed to rename index file ${oldIndexFileName} to ${file.name}. ${file.name} will be used as the index file.`)
+        }
 
 
-			// We weren't in a markdown file before, so we don't care
-			if (!(currentState.type == "markdown" && this.previousState.type == "markdown")) {
-				return;
-			}
+    }
 
-			// We didn't change files, so we don't care
-			if (currentState.state.file == this.previousState.state.file)
-				return;
-			const currentFile = this.app.vault.getAbstractFileByPath(currentState.state.file) as TFile
+    private async onLayoutChange() {
+        const currentLeaf = this.app.workspace.getMostRecentLeaf()
+        if (currentLeaf == null) {
+            return;
+        }
+        const currentState = currentLeaf.getViewState();
 
-			// We did not open an index file, so we need to check if the previous mode was set by this plugin
-			if (!isIndexFile(currentFile.path)) {
-				if (this.viewModeByPlugin) {
-					this.viewModeByPlugin = false
-					currentState.state.mode = "source"
-					await currentLeaf.setViewState(currentState)
-				}
-				return;
-			}
-			// 	// We are already inside the Preview Mode.
-			if (this.previousState.state.mode == "preview") {
-				return;
-			} else {
-				currentState.state.mode = "preview"
-				this.viewModeByPlugin = true
-				await currentLeaf.setViewState(currentState)
-			}
-		} finally {
-			if (currentState.type == "markdown")
-				this.previousState = currentLeaf.getViewState();
-		}
-	}
+        try {
+            // try {
+            if (this.previousState == null) {
+                this.previousState = currentLeaf.getViewState();
+            }
+            if (!this.plugin.settings.autoPreviewMode) {
+                return;
+            }
 
-	private async onCreate(file: TAbstractFile) {
-		if (file instanceof TFolder) {
-			const indexFilePath = this.indexFilePath(file.path);
-			await this.createIndexFile(indexFilePath);
-		}
-	}
+
+            // We weren't in a markdown file before, so we don't care
+            if (!(currentState.type == "markdown" && this.previousState.type == "markdown")) {
+                return;
+            }
+
+            // We didn't change files, so we don't care
+            if (currentState.state.file == this.previousState.state.file)
+                return;
+            const currentFile = this.app.vault.getAbstractFileByPath(currentState.state.file) as TFile
+
+            // We did not open an index file, so we need to check if the previous mode was set by this plugin
+            if (!isIndexFile(currentFile.path)) {
+                if (this.viewModeByPlugin) {
+                    this.viewModeByPlugin = false
+                    currentState.state.mode = "source"
+                    await currentLeaf.setViewState(currentState)
+                }
+                return;
+            }
+            // 	// We are already inside the Preview Mode.
+            if (this.previousState.state.mode == "preview") {
+                return;
+            } else {
+                currentState.state.mode = "preview"
+                this.viewModeByPlugin = true
+                await currentLeaf.setViewState(currentState)
+            }
+        } finally {
+            if (currentState.type == "markdown")
+                this.previousState = currentLeaf.getViewState();
+        }
+    }
+
+    private async onCreate(file: TAbstractFile) {
+        if (file instanceof TFolder) {
+            const indexFilePath = this.indexFilePath(file.path);
+            await this.createIndexFile(indexFilePath);
+        }
+    }
 }

--- a/src/modules/IndexContentProcessorModule.ts
+++ b/src/modules/IndexContentProcessorModule.ts
@@ -50,32 +50,32 @@ export class IndexContentProcessorModule extends MarkdownRenderChild {
 		if (folder instanceof TFile) {
 			const files = folder.parent?.children ?? []
 			const renderer = new MarkdownTextRenderer(this.plugin, this.app)
-			const codeBlockConfig = this.parseCodeBlockConfig()
+			const codeBlockConfig = this.parseCodeBlockConfig(this.codeBlockContent)
 			await MarkdownRenderer.renderMarkdown(renderer.buildMarkdownText(files, codeBlockConfig), this.container, this.filePath, this)
 		}
 	}
 
-	private parseCodeBlockConfig(): CodeBlockConfig {
-		const config: CodeBlockConfig = { ignore: [] }
-		
-		// Parse each line of the code block content
-		const lines = this.codeBlockContent.split("\n")
-		
+	private parseCodeBlockConfig(source: string): CodeBlockConfig {
+		const config: CodeBlockConfig = {};
+		const lines = source.split('\n');
+
 		for (const line of lines) {
-			const parts = line.split(":");
-			
-			if (parts.length >= 2) {
-				const [key, ...valueParts] = parts;
-				const value = valueParts.join(":").trim();
-				const trimmedKey = key.trim();
-				
-				if (trimmedKey === "ignore") {
-					// Split by comma and trim each pattern
-					config.ignore = value.split(",").map(s => s.trim());
+			if (line.trim().startsWith('title:')) {
+				config.title = line.split('title:')[1].trim();
+			} else if (line.trim().startsWith('type:')) {
+				config.type = line.split('type:')[1].trim();
+			} else if (line.trim().startsWith('ignore:')) {
+				const ignoreStr = line.split('ignore:')[1].trim();
+				config.ignore = ignoreStr.split(',').map(s => s.trim());
+			} else if (line.trim().startsWith('recursionLimit:')) {
+				const limitStr = line.split('recursionLimit:')[1].trim();
+				const limit = parseInt(limitStr);
+				if (!isNaN(limit)) {
+					config.recursionLimit = limit;
 				}
 			}
 		}
-		
-		return config
+
+		return config;
 	}
 }

--- a/src/modules/IndexContentProcessorModule.ts
+++ b/src/modules/IndexContentProcessorModule.ts
@@ -1,20 +1,24 @@
 import {App, MarkdownRenderChild, MarkdownRenderer, TAbstractFile, TFile} from "obsidian";
 import FolderIndexPlugin from "../main";
 import {MarkdownTextRenderer} from "../types/MarkdownTextRenderer";
-
+import {CodeBlockConfig} from "../models/CodeBlockConfig";
 
 export class IndexContentProcessorModule extends MarkdownRenderChild {
+	private codeBlockContent: string;
+
 	constructor(
 		private readonly app: App,
 		private readonly plugin: FolderIndexPlugin,
 		private readonly filePath: string,
-		private readonly container: HTMLElement
+		private readonly container: HTMLElement,
+		source: string
 	) {
 		super(container)
 		this.app = app
 		this.plugin = plugin
 		this.filePath = filePath
 		this.container = container
+		this.codeBlockContent = source
 	}
 
 	async onload() {
@@ -46,9 +50,32 @@ export class IndexContentProcessorModule extends MarkdownRenderChild {
 		if (folder instanceof TFile) {
 			const files = folder.parent?.children ?? []
 			const renderer = new MarkdownTextRenderer(this.plugin, this.app)
-			await MarkdownRenderer.renderMarkdown(renderer.buildMarkdownText(files), this.container, this.filePath, this)
+			const codeBlockConfig = this.parseCodeBlockConfig()
+			await MarkdownRenderer.renderMarkdown(renderer.buildMarkdownText(files, codeBlockConfig), this.container, this.filePath, this)
 		}
 	}
 
-
+	private parseCodeBlockConfig(): CodeBlockConfig {
+		const config: CodeBlockConfig = { ignore: [] }
+		
+		// Parse each line of the code block content
+		const lines = this.codeBlockContent.split("\n")
+		
+		for (const line of lines) {
+			const parts = line.split(":");
+			
+			if (parts.length >= 2) {
+				const [key, ...valueParts] = parts;
+				const value = valueParts.join(":").trim();
+				const trimmedKey = key.trim();
+				
+				if (trimmedKey === "ignore") {
+					// Split by comma and trim each pattern
+					config.ignore = value.split(",").map(s => s.trim());
+				}
+			}
+		}
+		
+		return config
+	}
 }

--- a/src/types/MarkdownTextRenderer.ts
+++ b/src/types/MarkdownTextRenderer.ts
@@ -193,9 +193,17 @@ export class MarkdownTextRenderer {
 				continue;
 			}
 			if (file instanceof TFolder && this.plugin.settings.recursiveIndexFiles) {
+				// 使用本地配置的递归层级限制（如果有的话），否则使用全局设置
+				const currentLimit = codeBlockConfig?.recursionLimit ?? this.plugin.settings.recursionLimit;
+				if (currentLimit !== -1 && this.getFolderDepth(file) >= currentLimit) {
+					continue;
+				}
 				fileTree.push(file)
 			}
 			if (file instanceof TFile) {
+				if (this.plugin.settings.markdownOnly && file.extension !== 'md') {
+					continue;
+				}
 				fileTree.push(file)
 			}
 		}
@@ -209,6 +217,16 @@ export class MarkdownTextRenderer {
 			fileTree.sort((a, b) => this.naturalSort(b.name, a.name))
 		}
 		return fileTree
+	}
+
+	private getFolderDepth(folder: TFolder): number {
+		let depth = 0;
+		let current = folder;
+		while (current.parent) {
+			depth++;
+			current = current.parent;
+		}
+		return depth;
 	}
 
 	private isPathIgnored(path: string, ignorePatterns: string[]): boolean {
@@ -255,4 +273,11 @@ export class MarkdownTextRenderer {
 		}
 		return indentText
 	}
+}
+
+interface CodeBlockConfig {
+	title?: string;
+	type?: string;
+	ignore?: string[];
+	recursionLimit?: number;  // 添加本地递归层级限制
 }

--- a/src/types/MarkdownTextRenderer.ts
+++ b/src/types/MarkdownTextRenderer.ts
@@ -274,10 +274,3 @@ export class MarkdownTextRenderer {
 		return indentText
 	}
 }
-
-interface CodeBlockConfig {
-	title?: string;
-	type?: string;
-	ignore?: string[];
-	recursionLimit?: number;  // 添加本地递归层级限制
-}

--- a/src/types/MarkdownTextRenderer.ts
+++ b/src/types/MarkdownTextRenderer.ts
@@ -2,6 +2,7 @@ import {App, HeadingCache, TAbstractFile, TFile, TFolder} from "obsidian";
 import FolderIndexPlugin from "../main";
 import {isExcludedPath, isIndexFile} from "./Utilities";
 import {SortBy} from "../models/PluginSettingsTab";
+import {CodeBlockConfig} from "../models/CodeBlockConfig";
 
 type FileTree = (TFile | TFolder)[]
 type HeaderWrapper = {
@@ -16,16 +17,16 @@ export class MarkdownTextRenderer {
 		this.app = app
 	}
 
-	public buildMarkdownText(filesInFolder: TAbstractFile[]): string {
-		const fileTree = this.buildFileTree(filesInFolder);
-		return this.buildStructureMarkdownText(fileTree, 0);
+	public buildMarkdownText(filesInFolder: TAbstractFile[], codeBlockConfig?: CodeBlockConfig): string {
+		const fileTree = this.buildFileTree(filesInFolder, codeBlockConfig);
+		return this.buildStructureMarkdownText(fileTree, 0, codeBlockConfig);
 	}
 
-	private buildStructureMarkdownText(fileTree: FileTree, indentLevel: number): string {
+	private buildStructureMarkdownText(fileTree: FileTree, indentLevel: number, codeBlockConfig?: CodeBlockConfig): string {
 		let markdownText = ""
 
 		for (const file of fileTree) {
-			if(isExcludedPath(file.path)){
+			if(isExcludedPath(file.path, codeBlockConfig)){
 				continue
 			}
 			if (file instanceof TFolder && this.plugin.settings.recursiveIndexFiles) {
@@ -40,7 +41,7 @@ export class MarkdownTextRenderer {
 					markdownText += this.buildMarkdownLinkString(file.name, null, indentLevel, true)
 				}
 				if (this.plugin.settings.recursionLimit === -1 || indentLevel < this.plugin.settings.recursionLimit) {
-					markdownText += this.buildStructureMarkdownText(this.buildFileTree(children), indentLevel + 1)
+					markdownText += this.buildStructureMarkdownText(this.buildFileTree(children, codeBlockConfig), indentLevel + 1, codeBlockConfig)
 				}
 			}
 			if (file instanceof TFile) {
@@ -134,7 +135,6 @@ export class MarkdownTextRenderer {
 		return `#${encodeURI(header.header.heading)}`
 	}
 
-
 	private checkIfFolderHasIndexFile(children: TAbstractFile[]): TFile | null {
 		for (const file of children) {
 			if (file instanceof TFile) {
@@ -162,32 +162,36 @@ export class MarkdownTextRenderer {
 		return headerTree
 	}
 
-	// Gets all headers that are children of the parentHeader
 	private getHeaderChildren(headers: HeadingCache[], startIndex: number, parentHeader: HeaderWrapper) {
 		const children: HeaderWrapper[] = []
 		if (startIndex > headers.length) {
 			return children
 		}
+
 		for (let i = startIndex; i < headers.length; i++) {
-			if (headers[i].level <= parentHeader.header.level) {
-				return children
+			const header = headers[i]
+			if (header.level <= parentHeader.header.level) {
+				break;
 			}
-			if (headers[i].level == parentHeader.header.level + 1) {
-				const wrappedHeader = {
+			if (header.level === parentHeader.header.level + 1) {
+				const child: HeaderWrapper = {
+					header: header,
 					parent: parentHeader,
-					header: headers[i],
-					children: [],
-				} as HeaderWrapper
-				wrappedHeader.children = this.getHeaderChildren(headers, i + 1, wrappedHeader)
-				children.push(wrappedHeader)
+					children: []
+				}
+				child.children = this.getHeaderChildren(headers, i + 1, child)
+				children.push(child)
 			}
 		}
 		return children
 	}
 
-	private buildFileTree(filesInFolder: TAbstractFile[]): FileTree {
+	private buildFileTree(filesInFolder: TAbstractFile[], codeBlockConfig?: CodeBlockConfig): FileTree {
 		const fileTree: FileTree = [];
 		for (const file of filesInFolder) {
+			if (codeBlockConfig?.ignore && this.isPathIgnored(file.path, codeBlockConfig.ignore)) {
+				continue;
+			}
 			if (file instanceof TFolder && this.plugin.settings.recursiveIndexFiles) {
 				fileTree.push(file)
 			}
@@ -205,6 +209,18 @@ export class MarkdownTextRenderer {
 			fileTree.sort((a, b) => this.naturalSort(b.name, a.name))
 		}
 		return fileTree
+	}
+
+	private isPathIgnored(path: string, ignorePatterns: string[]): boolean {
+		for (const pattern of ignorePatterns) {
+			if (pattern === "") continue;
+			// Escape special characters in the pattern except * which we'll use as wildcard
+			const escapedPattern = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '.*');
+			if (new RegExp(escapedPattern, 'i').test(path)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private naturalSort(a: string, b: string): number {


### PR DESCRIPTION
The `folder-index-content` code block now supports the following configuration options:

| Option | Description | Example |
|--------|-------------|---------|
| title | This will overwrite the Filename inside the Index | `title: My Custom Title` |
| ignore | Files/folders to exclude from the content (supports wildcards) | `ignore: *.pdf, *img*, temp` |
| recursionLimit | Override the global subfolder limit for this index | `recursionLimit: 2` |

Example:
````
```folder-index-content
title: Project Files
ignore: *.pdf, *img*, temp
recursionLimit: 2
```
````


And I add a new option:
![image](https://github.com/user-attachments/assets/5c6b6de6-c307-45cd-9809-5d780e0301ad)

---

Those codes are primarily wrote by AI (Windsurf), I just guided it and do tests.
It works on my 'puter, but I think it would be safer that you check it before merging it 🥺