### PR TITLE
fix: links in Graph View

### DIFF
--- a/src/modules/GraphManipulatorModule.ts
+++ b/src/modules/GraphManipulatorModule.ts
@@ -35,7 +35,7 @@ export class GraphManipulatorModule {
 
 	private onLayoutChange() {
 		this.graphsLeafs = this.app.workspace.getLeavesOfType("graph")
-		this.plugin.eventManager.emit("graphLeafUpdate", this.graphsLeafs)
+		this.onLeafUpdate(this.graphsLeafs)
 	}
 
 	private onLeafUpdate(leaves: WorkspaceLeaf[]) {


### PR DESCRIPTION
This should fix links between the folder index node and its files not showing in Graph View.

Problem:
<img width="1024" height="800" alt="Screenshot From 2025-09-09 12-33-16" src="https://github.com/user-attachments/assets/8198a927-52ef-45fb-8e50-936c046cec99" />

With this fix:
<img width="1024" height="800" alt="Screenshot From 2025-09-09 12-34-07" src="https://github.com/user-attachments/assets/2a0dd77d-7b58-46ef-8bdf-ed23e0fa4c4f" />
